### PR TITLE
Fix theme string parsing

### DIFF
--- a/src/functions/parseThemes.js
+++ b/src/functions/parseThemes.js
@@ -4,7 +4,7 @@
 export default function parseThemes(themeString, themes) {
   if (!themeString) return [];
 
-  const split = themeString.split(' ');
+  const split = themeString.split(/\s+/).filter(Boolean);
 
-  return split.map(theme => themes[theme.trim()]);
+  return split.map(theme => themes[theme]);
 }

--- a/src/tests/themeParsing.js
+++ b/src/tests/themeParsing.js
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+
+import parseThemes from '../functions/parseThemes';
+
+const { describe, it } = global;
+
+describe('theme parsing', () => {
+  it('should return [] with null input', () => {
+      const result = parseThemes(null, {});
+      expect(result).to.have.length(0);
+  });
+
+  it('should return [] with undefined input', () => {
+      const result = parseThemes(undefined, {});
+      expect(result).to.have.length(0);
+  });
+
+  it('should return [] with empty input', () => {
+      const result = parseThemes("", {});
+      expect(result).to.have.length(0);
+  });
+
+  it('should return [] when input is whitespace only', () => {
+    const result = parseThemes("   ", {});
+    expect(result).to.have.length(0);
+  });
+
+  it('should extract words ignoring all whitespace and return map values', () => {
+    const result = parseThemes("  hello    world \t foo bar ", {
+      hello: 1,
+      world: 2,
+      foo: 3,
+      bar: 4,
+    });
+    expect(result).to.deep.equal([1, 2, 3, 4]);
+  });
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2542,7 +2542,7 @@ interpret@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.0.1.tgz#d579fb7f693b858004947af39fa0db49f795602c"
 
-invariant@2.x.x, invariant@^2.2.0, invariant@^2.2.2:
+invariant@2.x.x, invariant@^2.2.0:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.2.tgz#9e1f56ac0acdb6bf303306f338be3b204ae60360"
   dependencies:


### PR DESCRIPTION
Theme string parsing has been improved:
- all whitespace is ignored, not only spaces
- leading whitespace, trailing whitespace and repeated whitespace don't result in empty names